### PR TITLE
feat(core/server): reject non-grpc requests

### DIFF
--- a/codegen/generator/src/main/scala/org/http4s/grpc/generator/Http4sGrpcServicePrinter.scala
+++ b/codegen/generator/src/main/scala/org/http4s/grpc/generator/Http4sGrpcServicePrinter.scala
@@ -21,10 +21,13 @@
 
 package org.http4s.grpc.generator
 
-import com.google.protobuf.Descriptors.{MethodDescriptor, ServiceDescriptor}
+import com.google.protobuf.Descriptors.MethodDescriptor
+import com.google.protobuf.Descriptors.ServiceDescriptor
+import scalapb.compiler.DescriptorImplicits
+import scalapb.compiler.FunctionalPrinter
 import scalapb.compiler.FunctionalPrinter.PrinterEndo
-import scalapb.compiler.{DescriptorImplicits, FunctionalPrinter, StreamType}
 import scalapb.compiler.ProtobufGenerator.asScalaDocBlock
+import scalapb.compiler.StreamType
 
 class Http4sGrpcServicePrinter(service: ServiceDescriptor, di: DescriptorImplicits) {
   import di._
@@ -102,7 +105,7 @@ class Http4sGrpcServicePrinter(service: ServiceDescriptor, di: DescriptorImplici
     _.call(service.methods.map(serviceMethodImplementation): _*)
 
   private[this] def serviceBindingImplementations: PrinterEndo =
-    _.add(s"$HttpRoutes.empty[F]").indent
+    _.add(s"$ServerGrpc.precondition[F]").indent
       .call(service.methods.map(serviceBindingImplementation): _*)
       .add(s""".combineK($ServerGrpc.methodNotFoundRoute("${service.getFullName()}"))""")
       .outdent

--- a/codegen/testing/src/test/scala/hello/world/TestServiceSuite.scala
+++ b/codegen/testing/src/test/scala/hello/world/TestServiceSuite.scala
@@ -73,7 +73,8 @@ class TestServiceSuite extends CatsEffectSuite with ScalaCheckEffectSuite {
 
   test("Routes returns 405 Method Not Allowed with Allow header on GET requests") {
     val client = Client.fromHttpApp(TestService.toRoutes(impl).orNotFound)
-    implicit val methodExceptPost = Arbitrary(Gen.oneOf(Method.all.filterNot(_ === Method.POST)))
+    implicit val methodExceptPost: Arbitrary[Method] =
+      Arbitrary(Gen.oneOf(Method.all.filterNot(_ === Method.POST)))
     forAllF { (meth: Method) =>
       client
         .run(

--- a/core/src/main/scala/org/http4s/grpc/ServerGrpc.scala
+++ b/core/src/main/scala/org/http4s/grpc/ServerGrpc.scala
@@ -18,7 +18,7 @@ import scala.concurrent.duration._
 
 object ServerGrpc {
   def precondition[F[_]: Monad]: HttpRoutes[F] = HttpRoutes.of[F] {
-    case req if req.method =!= Method.POST =>
+    case req if req.method != Method.POST =>
       Response(Status.MethodNotAllowed).withHeaders(Allow(Method.POST)).pure[F]
     case req if !hasGRPCContentType(req) =>
       Response[F](Status.UnsupportedMediaType).pure[F]

--- a/core/src/main/scala/org/http4s/grpc/ServerGrpc.scala
+++ b/core/src/main/scala/org/http4s/grpc/ServerGrpc.scala
@@ -1,6 +1,5 @@
 package org.http4s.grpc
 
-import cats.Applicative
 import cats.Monad
 import cats.effect._
 import cats.syntax.all._

--- a/core/src/main/scala/org/http4s/grpc/ServerGrpc.scala
+++ b/core/src/main/scala/org/http4s/grpc/ServerGrpc.scala
@@ -1,11 +1,14 @@
 package org.http4s.grpc
 
+import cats.Applicative
+import cats.Monad
 import cats.effect._
 import cats.syntax.all._
 import fs2._
 import org.http4s._
 import org.http4s.dsl.request._
 import org.http4s.grpc.codecs.NamedHeaders
+import org.http4s.headers.Allow
 import org.http4s.headers.Trailer
 import org.typelevel.ci._
 import scodec.Decoder
@@ -15,6 +18,16 @@ import java.util.concurrent.TimeoutException
 import scala.concurrent.duration._
 
 object ServerGrpc {
+  def precondition[F[_]: Monad]: HttpRoutes[F] = HttpRoutes.of[F] {
+    case req if req.method =!= Method.POST =>
+      Response(Status.MethodNotAllowed).withHeaders(Allow(Method.POST)).pure[F]
+    case req if !hasGRPCContentType(req) =>
+      Response[F](Status.UnsupportedMediaType).pure[F]
+  }
+
+  private def hasGRPCContentType[F[_]](req: Request[F]): Boolean = req.headers
+    .get(CIString("Content-Type"))
+    .exists(_.exists(_.value.startsWith("application/grpc")))
 
   def unaryToUnary[F[_]: Temporal, A, B]( // Stuff We can provide via codegen\
       decode: Decoder[A],

--- a/core/src/main/scala/org/http4s/grpc/SharedGrpc.scala
+++ b/core/src/main/scala/org/http4s/grpc/SharedGrpc.scala
@@ -10,9 +10,9 @@ private object SharedGrpc {
     .getOrElse(throw new Throwable("Impossible: This protocol is valid"))
 
   // TODO  Content-Coding → "identity" / "gzip" / "deflate" / "snappy" / {custom}
-  val GrpcEncoding: Header.Raw = org.http4s.Header.Raw(CIString("grpc-encoding"), "identity")
+  val GrpcEncoding: Header.Raw = Header.Raw(CIString("grpc-encoding"), "identity")
   val GrpcAcceptEncoding: Header.Raw =
     org.http4s.Header.Raw(CIString("grpc-accept-encoding"), "identity")
-  val TE: Header.Raw = org.http4s.Header.Raw(CIString("te"), "trailers")
+  val TE: Header.Raw = Header.Raw(CIString("te"), "trailers")
 
 }


### PR DESCRIPTION
If **Content-Type** does not begin with "application/grpc", gRPC servers SHOULD respond with HTTP status of 415 (Unsupported Media Type), according to gRPC specification.

In addition, some of gRPC implementations return 405 if request method is not POST as gRPC speccification expects method to be POST.

Note:
there is an ongoing discussion on how to handle invalid requests https://github.com/Nikkei/vessel-manifests/pull/176732