### PR TITLE
Drop native and upgrade scalapb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         os: [ubuntu-22.04]
         scala: [2.13, 3]
         java: [temurin@8, temurin@11, temurin@17]
-        project: [http4s-grpcJVM, http4s-grpcJS, http4s-grpcNative]
+        project: [http4s-grpcJVM, http4s-grpcJS]
         exclude:
           - scala: 3
             java: temurin@11
@@ -40,10 +40,6 @@ jobs:
           - project: http4s-grpcJS
             java: temurin@11
           - project: http4s-grpcJS
-            java: temurin@17
-          - project: http4s-grpcNative
-            java: temurin@11
-          - project: http4s-grpcNative
             java: temurin@17
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
@@ -106,10 +102,6 @@ jobs:
         if: matrix.project == 'http4s-grpcJS'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' Test/scalaJSLinkerResult
 
-      - name: nativeLink
-        if: matrix.project == 'http4s-grpcNative'
-        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' Test/nativeLink
-
       - name: Test
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' test
 
@@ -131,11 +123,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p core/.native/target core/.js/target codegen/plugin/target core/.jvm/target codegen/generator/target project/target
+        run: mkdir -p core/.js/target codegen/plugin/target core/.jvm/target codegen/generator/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar core/.native/target core/.js/target codegen/plugin/target core/.jvm/target codegen/generator/target project/target
+        run: tar cf targets.tar core/.js/target codegen/plugin/target core/.jvm/target codegen/generator/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
@@ -221,16 +213,6 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
-      - name: Download target directories (2.13, http4s-grpcNative)
-        uses: actions/download-artifact@v4
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13-http4s-grpcNative
-
-      - name: Inflate target directories (2.13, http4s-grpcNative)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
       - name: Download target directories (3, http4s-grpcJVM)
         uses: actions/download-artifact@v4
         with:
@@ -247,16 +229,6 @@ jobs:
           name: target-${{ matrix.os }}-${{ matrix.java }}-3-http4s-grpcJS
 
       - name: Inflate target directories (3, http4s-grpcJS)
-        run: |
-          tar xf targets.tar
-          rm targets.tar
-
-      - name: Download target directories (3, http4s-grpcNative)
-        uses: actions/download-artifact@v4
-        with:
-          name: target-${{ matrix.os }}-${{ matrix.java }}-3-http4s-grpcNative
-
-      - name: Inflate target directories (3, http4s-grpcNative)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,6 @@ ThisBuild / developers := List(
   tlGitHubDev("christopherdavenport", "Christopher Davenport")
 )
 ThisBuild / tlCiReleaseBranches := Seq("main")
-ThisBuild / tlSonatypeUseLegacyHost := false
-
 ThisBuild / tlMimaPreviousVersions := Set()
 
 val Scala212 = "2.12.20"
@@ -38,7 +36,7 @@ lazy val `http4s-grpc` = tlCrossRootProject
   )
   .disablePlugins(HeaderPlugin)
 
-lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
+lazy val core = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Pure)
   .in(file("core"))
   .settings(
@@ -102,7 +100,7 @@ lazy val codeGeneratorPlugin = project
   )
   .disablePlugins(HeaderPlugin, ScalafixPlugin)
 
-lazy val codeGeneratorTesting = crossProject(JVMPlatform, JSPlatform, NativePlatform)
+lazy val codeGeneratorTesting = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Pure)
   .in(file("codegen/testing"))
   .enablePlugins(LocalCodeGenPlugin, BuildInfoPlugin, NoPublishPlugin)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,12 +1,9 @@
 addSbtPlugin("org.http4s" % "sbt-http4s-org" % "0.17.6")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.17.0")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.17")
-addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.2")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
 
 addSbtPlugin(
   "com.thesamet" % "sbt-protoc" % "1.0.7"
 ) // Because sbt-protoc-gen-project brings in 1.0.4
 addSbtPlugin("com.thesamet" % "sbt-protoc-gen-project" % "0.1.8")
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.14"
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.17"


### PR DESCRIPTION
Since we are stuck on 0.4 and the world have moved on. We have not published anything yet, so that means we have no real problem with not publishing native bindings.