### PR TITLE
Publish for Scala Native 0.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         os: [ubuntu-22.04]
         scala: [2.13, 3]
         java: [temurin@8, temurin@11, temurin@17]
-        project: [http4s-grpcJVM, http4s-grpcJS]
+        project: [http4s-grpcJVM, http4s-grpcJS, http4s-grpcNative]
         exclude:
           - scala: 3
             java: temurin@11
@@ -40,6 +40,10 @@ jobs:
           - project: http4s-grpcJS
             java: temurin@11
           - project: http4s-grpcJS
+            java: temurin@17
+          - project: http4s-grpcNative
+            java: temurin@11
+          - project: http4s-grpcNative
             java: temurin@17
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
@@ -102,6 +106,10 @@ jobs:
         if: matrix.project == 'http4s-grpcJS'
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' Test/scalaJSLinkerResult
 
+      - name: nativeLink
+        if: matrix.project == 'http4s-grpcNative'
+        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' Test/nativeLink
+
       - name: Test
         run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' test
 
@@ -123,11 +131,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p core/.js/target codegen/plugin/target core/.jvm/target codegen/generator/target project/target
+        run: mkdir -p core/.native/target core/.js/target codegen/plugin/target core/.jvm/target codegen/generator/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar core/.js/target codegen/plugin/target core/.jvm/target codegen/generator/target project/target
+        run: tar cf targets.tar core/.native/target core/.js/target codegen/plugin/target core/.jvm/target codegen/generator/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
@@ -213,6 +221,16 @@ jobs:
           tar xf targets.tar
           rm targets.tar
 
+      - name: Download target directories (2.13, http4s-grpcNative)
+        uses: actions/download-artifact@v6
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-2.13-http4s-grpcNative
+
+      - name: Inflate target directories (2.13, http4s-grpcNative)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
       - name: Download target directories (3, http4s-grpcJVM)
         uses: actions/download-artifact@v6
         with:
@@ -229,6 +247,16 @@ jobs:
           name: target-${{ matrix.os }}-${{ matrix.java }}-3-http4s-grpcJS
 
       - name: Inflate target directories (3, http4s-grpcJS)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (3, http4s-grpcNative)
+        uses: actions/download-artifact@v6
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3-http4s-grpcNative
+
+      - name: Inflate target directories (3, http4s-grpcNative)
         run: |
           tar xf targets.tar
           rm targets.tar
@@ -316,7 +344,7 @@ jobs:
       - name: Submit Dependencies
         uses: scalacenter/sbt-dependency-submission@v2
         with:
-          modules-ignore: http4s-grpcjvm_2.13 http4s-grpcjvm_3 codegeneratortesting_sjs1_2.13 codegeneratortesting_sjs1_3 site_2.13 site_3 http4s-grpcjs_2.13 http4s-grpcjs_3 http4s-grpcnative_2.13 http4s-grpcnative_3 sbt-http4s-org-scalafix-internal_2.13 sbt-http4s-org-scalafix-internal_3 codegeneratortesting_2.13 codegeneratortesting_3
+          modules-ignore: http4s-grpcjvm_2.13 http4s-grpcjvm_3 codegeneratortesting_native0.5_2.13 codegeneratortesting_native0.5_3 codegeneratortesting_sjs1_2.13 codegeneratortesting_sjs1_3 site_2.13 site_3 http4s-grpcjs_2.13 http4s-grpcjs_3 http4s-grpcnative_2.13 http4s-grpcnative_3 sbt-http4s-org-scalafix-internal_2.13 sbt-http4s-org-scalafix-internal_3 codegeneratortesting_2.13 codegeneratortesting_3
           configs-ignore: test scala-tool scala-doc-tool test-internal
 
   site:

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ inThisBuild(
   Seq(
     crossScalaVersions := Seq(scala213Version, scala3Version),
     scalaVersion := scala213Version,
-    tlBaseVersion := "0.2",
+    tlBaseVersion := "0.3",
     organizationName := "Christopher Davenport",
     startYear := Some(2023),
     licenses := Seq(License.MIT),
@@ -31,7 +31,7 @@ lazy val `http4s-grpc` = tlCrossRootProject
   .aggregate(core, codeGenerator, codeGeneratorTesting, codeGeneratorPlugin)
   .settings(unusedCompileDependenciesFilter -= moduleFilter())
 
-lazy val core = crossProject(JVMPlatform, JSPlatform)
+lazy val core = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .crossType(CrossType.Pure)
   .in(file("core"))
   .settings(
@@ -51,6 +51,9 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
   )
   .jsSettings(
     scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
+  )
+  .nativeSettings(
+    tlVersionIntroduced := List("2.13", "3").map(_ -> "0.3.0").toMap
   )
 
 lazy val codeGenerator =
@@ -96,7 +99,7 @@ lazy val codeGeneratorPlugin = project
   )
   .disablePlugins(ScalafixPlugin)
 
-lazy val codeGeneratorTesting = crossProject(JVMPlatform, JSPlatform)
+lazy val codeGeneratorTesting = crossProject(JVMPlatform, JSPlatform, NativePlatform)
   .crossType(CrossType.Pure)
   .in(file("codegen/testing"))
   .enablePlugins(LocalCodeGenPlugin, BuildInfoPlugin, NoPublishPlugin)
@@ -120,6 +123,9 @@ lazy val codeGeneratorTesting = crossProject(JVMPlatform, JSPlatform)
     ),
     githubWorkflowArtifactUpload := false,
     unusedCompileDependenciesFilter -= moduleFilter(),
+  )
+  .nativeSettings(
+    tlVersionIntroduced := List("2.13", "3").map(_ -> "0.3.0").toMap
   )
   .disablePlugins(ScalafixPlugin)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,5 +4,6 @@ addSbtPlugin("com.thesamet" % "sbt-protoc-gen-project" % "0.1.8")
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.8")
 addSbtPlugin("org.http4s" % "sbt-http4s-org" % "2.0.5")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.21.0")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.5.11")
 
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.20"


### PR DESCRIPTION
Scala Native support was dropped in #162 back in January 2025. Now that http4s is available on Scala Native 0.5, we can once again publish for Scala Native.

Closes #163. Closes #171.